### PR TITLE
refactor: flag for Argo CD token

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Edit your `~/.cursor/mcp.json` file with the following contents:
     "argocd-mcp": {
       "command": "<path/to/argocd-mcp>",
       "args": [
-        "--argocd-token-file",
-        "<path/to/token-file>",
+        "--argocd-token",
+        "<token>",
         "--argocd-url",
         "<url>",
         "--insecure",
@@ -58,7 +58,7 @@ Edit your `~/.cursor/mcp.json` file with the following contents:
 [Install Goose](https://block.github.io/goose/docs/getting-started/installation) then [add the MCP server](https://block.github.io/goose/docs/getting-started/using-extensions#mcp-servers) with the following command line to run:
 
 ```
-<path/to/argocd-mcp> --argocd-token-file <path/to/token-file> --argocd-url <url> --insecure <true|false>
+<path/to/argocd-mcp> --argocd-token <token> --argocd-url <url> --insecure <true|false>
 ```
 
 ## Testing with Claude Desktop App
@@ -76,8 +76,8 @@ and add the following MCP server definition:
         "argocd-mcp": {
             "command": "<path/to/argocd-mcp>",
             "args": [
-                "--argocd-token-file"
-                "<path/to/token-file>",
+                "--argocd-token"
+                "<token>",
                 "--argocd-url",
                 "<url>",
                 "--insecure"

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -1,0 +1,48 @@
+package configuration
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+type Configuration struct {
+	URL      string
+	Token    string
+	Insecure bool
+}
+
+func New() (Configuration, error) {
+	return NewFromFlagSet(flag.CommandLine, os.Args[1:])
+}
+
+func NewFromFlagSet(f *flag.FlagSet, args []string) (Configuration, error) {
+	var url, token, insecureStr string
+	var insecure bool
+	f.StringVar(&url, "argocd-url", "", "URL of the Argo CD server to query")
+	f.StringVar(&token, "argocd-token", "", "The token to query Argo CD (will be expanded if specified as $ENV_VAR)")
+	f.StringVar(&insecureStr, "insecure", "false", "Allow insecure TLS connections")
+	if err := f.Parse(args); err != nil {
+		return Configuration{}, err
+	}
+	if strings.HasPrefix(url, "$") {
+		url = os.ExpandEnv(url)
+	}
+	if strings.HasPrefix(token, "$") {
+		token = os.ExpandEnv(token)
+	}
+	if strings.HasPrefix(insecureStr, "$") {
+		insecureStr = os.ExpandEnv(insecureStr)
+	}
+	insecure, err := strconv.ParseBool(insecureStr)
+	if err != nil {
+		return Configuration{}, err
+	}
+	return Configuration{
+		URL:      url,
+		Token:    token,
+		Insecure: insecure,
+	}, nil
+}

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -1,0 +1,49 @@
+package configuration_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/xcoulon/argocd-mcp/internal/configuration"
+
+	flag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfiguration(t *testing.T) {
+
+	t.Run("using plain values", func(t *testing.T) {
+		// given
+		f := flag.NewFlagSet("test", flag.ContinueOnError)
+
+		// when
+		cfg, err := configuration.NewFromFlagSet(f, []string{"--argocd-url", "https://argocd-server", "--argocd-token", "secure-token", "--insecure", "true"})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "https://argocd-server", cfg.URL)
+		assert.Equal(t, "secure-token", cfg.Token)
+		assert.True(t, cfg.Insecure)
+	})
+
+	t.Run("using env var expansion", func(t *testing.T) {
+		// given
+		os.Setenv("ARGOCD_URL", "https://argocd-server")
+		defer os.Unsetenv("ARGOCD_URL")
+		os.Setenv("ARGOCD_TOKEN", "secure-token")
+		defer os.Unsetenv("ARGOCD_TOKEN")
+		os.Setenv("ARGOCD_INSECURE", "true")
+		defer os.Unsetenv("ARGOCD_INSECURE")
+		f := flag.NewFlagSet("test", flag.ContinueOnError)
+
+		// when
+		cfg, err := configuration.NewFromFlagSet(f, []string{"--argocd-url", "$ARGOCD_URL", "--argocd-token", "$ARGOCD_TOKEN", "--insecure", "$ARGOCD_INSECURE"})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "https://argocd-server", cfg.URL)
+		assert.Equal(t, "secure-token", cfg.Token)
+		assert.True(t, cfg.Insecure)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -4,24 +4,19 @@ import (
 	"log/slog"
 	"os"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/xcoulon/argocd-mcp/internal/argocdmcp"
+	"github.com/xcoulon/argocd-mcp/internal/configuration"
 	"github.com/xcoulon/converse-mcp/pkg/server"
 )
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{}))
-	url := flag.String("argocd-url", "", "URL of the Argo CD server to query")
-	tokenFile := flag.String("argocd-token-file", "", "File with the token to query Argo CD")
-	insecure := flag.Bool("insecure", false, "Allow insecure TLS connections")
-	flag.Parse()
-	token, err := os.ReadFile(*tokenFile)
+	cfg, err := configuration.New()
 	if err != nil {
-		logger.Error("failed to read token file", "error", err)
+		logger.Error("failed to load configuration", "error", err.Error())
 		os.Exit(1)
 	}
-	b := argocdmcp.NewHTTPClient(*url, string(token), *insecure)
+	b := argocdmcp.NewHTTPClient(cfg.URL, cfg.Token, cfg.Insecure)
 	srv := argocdmcp.NewServer(logger, b)
 	srv.Start(server.StdioChannel)
 	logger.Info("server started")


### PR DESCRIPTION
pass the value via a flag, instead of specifying the file where the value is stored
include env var expansion when the value is in the form of `` or ``

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
